### PR TITLE
FIxed white stripes in GetMap result

### DIFF
--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTiffTileDataSetBuilder.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTiffTileDataSetBuilder.java
@@ -96,8 +96,8 @@ class GeoTiffTileDataSetBuilder {
         for ( TileMatrix tm : tms.getTileMatrices() ) {
             int xoff = (int) Math.round( x / tm.getTileWidth() );
             int yoff = (int) Math.round( y / tm.getTileHeight() );
-            int numx = (int) Math.round( envelope.getSpan0() / tm.getTileWidth() );
-            int numy = (int) Math.round( envelope.getSpan1() / tm.getTileHeight() );
+            int numx = (int) Math.ceil( envelope.getSpan0() / tm.getTileWidth() );
+            int numy = (int) Math.ceil( envelope.getSpan1() / tm.getTileHeight() );
             levels.add( new GeoTIFFTileDataLevel( tm, file, idx++, xoff, yoff, numx, numy ) );
         }
 


### PR DESCRIPTION
Use Math.ceil() instead of Math.round() as in org.deegree.tile.tilematrixset.geotiff.GeoTIFFTileMatrixSetProvider.create(URL) to ensure the same number of tiles in TileMatrix and GeoTIFFTileDataLevel
